### PR TITLE
Add link to doc

### DIFF
--- a/input/pagecontent/about.md
+++ b/input/pagecontent/about.md
@@ -19,5 +19,5 @@ L'onglet de [téléchargement](downloads.html) vous permettra de télécharger :
 Ce guide a été généré à partir de ce [repository GitHub](https://github.com/ansforge/FIG_ans-ig-PDSm), qui contient également l'historique des commits.
 
 Liens utiles :
-- [Wiki ANS sur les IGs](https://github.com/ansforge/FIG_ans-ig-sample/wiki) (en cours de construction)
+- [Documentation ANS sur les IGs](https://interop.esante.gouv.fr/ig/documentation)
 - [Documentation IG Publisher](https://confluence.hl7.org/display/FHIR/IG+Publisher+Documentation)

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -1,16 +1,17 @@
 ### Introduction
 
-Il s'agit d'un exemple d'Implementation Guide de l'ANS, à prendre comme base pour créer de nouveaux IGs. 
-
-Selon la documentation officielle, cette page d'accueil de l'IG doit contenir :
-* De quoi parle l'IG (En termes non expert, compréhensible par un patient)
-* Des détails techniques sur le contexte et le besoin
-
+Définir ici de quoi parle l'IG (En termes non expert, compréhensible par un patient). Rajouter également les détails techniques sur le contexte et le besoin de cet IG
 
 Les principales sections de l'IG  sont :
 * Le contexte de l'IG et les points dont les implémenteurs doivent être familier avant dans s'avoir plus sur l'IG
 * Ce que les Implémenteurs doivent mettre en place
 * Un onglet "télécharger"
+
+Toujours laisser l'onglet "Ressources de conformité" pour s'assurer d'une cohérence globales entre tous les IGs
+
+### Project scope
+
+Définir en quelques lignes en anglais quel est le périmètre du projet
 
 
 ### Auteurs et contributeurs

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -50,6 +50,7 @@ menu:
     Autres ressources:
         Sécurité: securite.html
         Téléchargements et usage: downloads.html
+        "Documentation sur les IG": new-tab https://interop.esante.gouv.fr/ig/documentation/
         "Spécifications FHIR ": new-tab {{site.data.fhir.path}}index.html
         "Site de l'ANS ": new-tab https://esante.gouv.fr/
     A propos de ce guide: about.html


### PR DESCRIPTION
- Ajout d'un lien vers la documentation
- Changement de index.md pour rajouter une partie "Project scope" pour définir le périmètre du guide en quelques lignes en anglais
- Remplacement du lien wiki par lien vers la documentation