### PR TITLE
add comment about name in sushi-config.yaml

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -2,7 +2,7 @@
 
 id: ans.fhir.fr.[code]
 canonical: https://interop.esante.gouv.fr/ig/fhir/[code] # the last part of canonical and id must be the same
-name: ExampleIG
+name: ExampleIG # Should be an acronym
 title: ANS IG Example
 publisher:
   name: ANS


### PR DESCRIPTION
Pour éviter des erreurs et uniformisation, rajout d'un commentaire pour dire ce qui est attendu dans name.
On attend l'acronyme. Ex : ROR dans name et Repertoire Offre Ressources dans title