### PR TITLE
Mise à jour de la stu note

### DIFF
--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -3,8 +3,7 @@
 [Add a brief description of this IG in English]
 </p>
 
-<!--  A décommenter lors de la publication -->
-
+{% if site.data.info.releaselabel == 'ci-build' %}
 <div style="width: 65%">
     <blockquote class="stu-note">
     <p>
@@ -12,8 +11,7 @@
     </p>
     </blockquote>
 </div>
-
-
+{% endif %}
 
 <!--  A décommenter si CI-SIS
 <div class="figure">


### PR DESCRIPTION
## Description des changements

Hello @sdemeyANS @SEBELIN @M-Priour @breverseau !
J'ai trouvé un moyen de rajouter la stu note redirigeant vers la version courante automatiquement dans le cas où le release label est 'ci-build' !

Si jamais ça vous intéresse :)

## Preview

https://ansforge.github.io/IG-fhir-[nom repo]/[ajouter_nom_de_la_branche]/ig